### PR TITLE
Allow to specify user and group owner for volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This module is meant for use with Terraform 0.12. If you haven't upgraded and ne
 - configurable subnet masks
 - configurable disk sizes and types
 - configure which network tags will be allowed to access
+- option to specify user and/or group ownership for the volumes
 
 
 ## 2. Usage:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ define cluster module, the example setup can look like::
 
 ```hcl
 module "cluster" {
-  source              = "github.com/erento/terraform-google-glusterfs?ref=2.0.0"
+  source              = "github.com/erento/terraform-google-glusterfs?ref=2.1.0"
   server_prefix       = "glusterfs-server"
   data_disk_prefix    = "glusterfs-brick"
   subnet_mask         = "10.0.0.0/24"

--- a/files/glusterfs_provision_server.sh
+++ b/files/glusterfs_provision_server.sh
@@ -26,6 +26,12 @@ if [[ $HOSTNAME =~ -0$ ]]; then
 	for volume_name in ${volume_names}; do
 		if [[ -z $(sudo gluster volume list | grep $volume_name) ]]; then
 			sudo gluster volume create $volume_name replica ${replicas_number} $(for peer in $CLUSTER_SIZE; do echo -n "${server_prefix}-$peer:/data/brick1/$volume_name "; done) force
+			if [ ! -z "${user}" ]; then
+				sudo gluster volume set $volume_name storage.owner-uid `id -u ${user}`
+			fi
+			if [ ! -z "${group}" ]; then
+				sudo gluster volume set $volume_name storage.owner-gid `id -u ${group}`
+			fi
 			sudo gluster volume start $volume_name
 		fi
 	done

--- a/main.tf
+++ b/main.tf
@@ -82,6 +82,8 @@ data "template_file" "provision_script" {
     cluster_size    = var.cluster_size
     server_prefix   = var.server_prefix
     volume_names    = join(" ", var.volume_names)
+    group           = var.group
+    user            = var.user
     replicas_number = var.replicas_number
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -122,3 +122,13 @@ variable "vm_dns_setting" {
 EOF
 
 }
+
+variable "user" {
+  description = "User ownership of the volumes"
+  default = ""
+}
+
+variable "group" {
+  description = "Group ownership of the volumes"
+  default = ""
+}


### PR DESCRIPTION
Having non-root user in the container is good practise and security recommendation.
The PR is to allow to specify user and/or group ownership for the volumes in the cluster, so the custom user can read and writes files to the volumes.
